### PR TITLE
Fix using correct Test::Builder singleton instance.

### DIFF
--- a/lib/Test/BDD/Cucumber/Executor.pm
+++ b/lib/Test/BDD/Cucumber/Executor.pm
@@ -386,7 +386,6 @@ sub dispatch {
     my $result;
     {
         # Localize test builder
-        local $Test::Builder::Test = $tb_return->{'builder'};
         local $tester_delegator->{Object} = $tb_return->{'builder'};
 
         # Execute!

--- a/lib/Test/BDD/Cucumber/Executor.pm
+++ b/lib/Test/BDD/Cucumber/Executor.pm
@@ -18,10 +18,16 @@ use List::MoreUtils qw/pairwise/;
 use Test::Builder;
 use Number::Range;
 
+use Test::BDD::Cucumber::TestBuilderDelegator;
 use Test::BDD::Cucumber::StepContext;
 use Test::BDD::Cucumber::Util;
 use Test::BDD::Cucumber::Model::Result;
 use Test::BDD::Cucumber::Errors qw/parse_error_from_line/;
+
+my $original_tester = Test::Builder->new();
+my $tester_delegator = Test::BDD::Cucumber::TestBuilderDelegator->new();
+$tester_delegator->{Object} = $original_tester;
+$Test::Builder::Test = $tester_delegator;
 
 =head1 METHODS
 
@@ -381,6 +387,7 @@ sub dispatch {
     {
         # Localize test builder
         local $Test::Builder::Test = $tb_return->{'builder'};
+        local $tester_delegator->{Object} = $tb_return->{'builder'};
 
         # Execute!
         eval {

--- a/lib/Test/BDD/Cucumber/TestBuilderDelegator.pm
+++ b/lib/Test/BDD/Cucumber/TestBuilderDelegator.pm
@@ -1,0 +1,33 @@
+package Test::BDD::Cucumber::TestBuilderDelegator;
+# This package is inspired by Test::Tester::Delegate
+
+use strict;
+use warnings;
+
+use vars '$AUTOLOAD';
+
+sub new
+{
+    my $pkg = shift;
+
+    my $obj = shift;
+    my $self = bless {}, $pkg;
+
+    return $self;
+}
+
+sub AUTOLOAD
+{
+    my ($sub) = $AUTOLOAD =~ /.*::(.*?)$/;
+
+    return if $sub eq "DESTROY";
+
+    my $obj = $_[0]->{Object};
+
+    my $ref = $obj->can($sub);
+    shift(@_);
+    unshift(@_, $obj);
+    goto &$ref;
+}
+
+1;

--- a/t/320_test_builder.t
+++ b/t/320_test_builder.t
@@ -1,0 +1,65 @@
+#!perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Differences;
+use Test::BDD::Cucumber::Harness::Data;
+use Test::BDD::Cucumber::Loader;
+
+my $TEST_DIRECTORY="t/test_builder";
+
+sub run_tests {
+    my $harness = Test::BDD::Cucumber::Harness::Data->new();
+    for my $directory ( $TEST_DIRECTORY ) {
+        my ( $executor, @features ) = Test::BDD::Cucumber::Loader->load($directory);
+        die "No features found in $directory" unless @features;
+
+        $executor->execute( $_, $harness ) for @features;
+    }
+    return @{ $harness->results };
+}
+
+my @results = run_tests();
+
+is(scalar @results, 4);
+
+# Scenario A
+is($results[0]{result}, 'passing');
+eq_or_diff($results[0]{output}, <<EOF);
+ok 1 - Starting to execute step: the number 5 is odd
+ok 2 - Number 5 is odd
+1..2
+EOF
+
+# Scenario B
+is($results[1]{result}, 'passing');
+eq_or_diff($results[1]{output}, <<EOF);
+ok 1 - Starting to execute step: the number 8 is even
+ok 2 - Number 8 is even
+1..2
+EOF
+
+# Scenario C
+is($results[2]{result}, 'failing');
+eq_or_diff($results[2]{output}, <<EOF);
+ok 1 - Starting to execute step: the number 11 is even
+not ok 2 - Number 11 is even
+
+#   Failed test 'Number 11 is even'
+#   at $TEST_DIRECTORY/step_definitions/mock_steps.pl line 27.
+1..2
+EOF
+
+# Scenario D
+is($results[3]{result}, 'failing');
+eq_or_diff($results[3]{output}, <<EOF);
+ok 1 - Starting to execute step: the number 12 is odd
+not ok 2 - Number 12 is odd
+
+#   Failed test 'Number 12 is odd'
+#   at $TEST_DIRECTORY/step_definitions/mock_steps.pl line 23.
+1..2
+EOF
+
+done_testing();

--- a/t/320_test_builder.t
+++ b/t/320_test_builder.t
@@ -47,7 +47,7 @@ ok 1 - Starting to execute step: the number 11 is even
 not ok 2 - Number 11 is even
 
 #   Failed test 'Number 11 is even'
-#   at $TEST_DIRECTORY/step_definitions/mock_steps.pl line 27.
+#   at $TEST_DIRECTORY/step_definitions/mock_steps.pl line 30.
 1..2
 EOF
 
@@ -58,7 +58,7 @@ ok 1 - Starting to execute step: the number 12 is odd
 not ok 2 - Number 12 is odd
 
 #   Failed test 'Number 12 is odd'
-#   at $TEST_DIRECTORY/step_definitions/mock_steps.pl line 23.
+#   at $TEST_DIRECTORY/step_definitions/mock_steps.pl line 26.
 1..2
 EOF
 

--- a/t/test_builder/mock.feature
+++ b/t/test_builder/mock.feature
@@ -1,0 +1,13 @@
+Feature: Test global Test::Builder
+
+  Scenario: A
+    Given the number 5 is odd
+
+  Scenario: B
+    Given the number 8 is even
+
+  Scenario: C
+    Given the number 11 is even
+
+  Scenario: D
+    Given the number 12 is odd

--- a/t/test_builder/step_definitions/mock_steps.pl
+++ b/t/test_builder/step_definitions/mock_steps.pl
@@ -1,0 +1,28 @@
+#!perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::BDD::Cucumber::StepFile;
+use Test::Builder;
+
+# Test global builder used in some Test::* packages
+my $Tester = Test::Builder->new();
+
+sub is_odd {
+    my ($number) = @_;
+    $Tester->ok($number % 2, "Number $number is odd");
+}
+
+sub is_even {
+    my ($number) = @_;
+    $Tester->ok(!($number % 2), "Number $number is even");
+}
+
+Step qr/the number (\d+) is odd/ => sub {
+    is_odd($1);
+};
+
+Step qr/the number (\d+) is even/ => sub {
+    is_even($1);
+};

--- a/t/test_builder/step_definitions/mock_steps.pl
+++ b/t/test_builder/step_definitions/mock_steps.pl
@@ -7,16 +7,19 @@ use Test::BDD::Cucumber::StepFile;
 use Test::Builder;
 
 # Test global builder used in some Test::* packages
-my $Tester = Test::Builder->new();
+my $Tester;
+sub get_tester {
+    return $Tester //= Test::Builder->new();
+}
 
 sub is_odd {
     my ($number) = @_;
-    $Tester->ok($number % 2, "Number $number is odd");
+    get_tester()->ok($number % 2, "Number $number is odd");
 }
 
 sub is_even {
     my ($number) = @_;
-    $Tester->ok(!($number % 2), "Number $number is even");
+    get_tester()->ok(!($number % 2), "Number $number is even");
 }
 
 Step qr/the number (\d+) is odd/ => sub {


### PR DESCRIPTION
because some Test::* modules using global "Test::Builder" singleton
initialized only during "use (test-module)".

This fix is inspired by implemention of Test::Tester.