### PR TITLE
use_module('lib') before importing

### DIFF
--- a/lib/App/pherkin.pm
+++ b/lib/App/pherkin.pm
@@ -141,7 +141,7 @@ sub _process_arguments {
     # Munge the output harness
     $self->_initialize_harness( $harness || "TermColor" );
 
-    lib->import(@$includes) if @$includes;
+    use_module('lib')->import(@$includes) if @$includes;
 
     # Store any extra step paths
     $self->step_paths($step_paths);


### PR DESCRIPTION
On Perl 5.22 on Precise64 locally, lib->import silently failed to add the includes to INC, seemingly because `lib` is unused.
This commit ensures it's used (leveraging use_module, as per mst's suggestion)