### PR TITLE
Improve extension config

### DIFF
--- a/bin/pherkin
+++ b/bin/pherkin
@@ -115,6 +115,36 @@ end of multi-item ones.
 If you specify C<--debug-profile> then information showing which profile is
 loaded and how is printed to STDOUT, and then `pherkin` terminates.
 
+=head2 EXTENSION CONFIGURATION
+
+Extensions named in the C<extensions> section of the configuration will
+be loaded with the configuration from the configuration file:
+
+ default:
+   includes:
+      # include location where extensions reside on disk
+      - t/lib
+   extensions:
+      # extension with configuration
+      Test::CucumberPush:
+          key1: value1
+          key2: value2
+      # extension without configuration
+      Test::CucumberPop:
+
+Notice that contrary to all other configuration parameters, the names
+of the extensions are not prefixed with a dash (i.e. '- t/lib' vs
+'Test::CucumberPush').
+
+The example above is the equivalent of
+
+  use Test::CucumberPush;
+  use Test::CucumberPop;
+
+  Test::CucumberPush->new({ 'key1' => 'value1', 'key2' => 'value2' });
+  Test::CucumberPop->new();
+
+
 =head1 AUTHOR
 
 Peter Sergeant C<pete@clueball.com>

--- a/lib/App/pherkin.pm
+++ b/lib/App/pherkin.pm
@@ -199,7 +199,8 @@ sub _load_config {
                 push( @arguments, $key, $_ ) for @$value;
             } else {
                 die $profile_problem->(
-                    "Option $key is a [$reftype] but can only be a HASH" )
+"Option $key is a [$reftype] but can only be a HASH as '$key' is"
+. " a special case - see the documentation for details")
                   unless $reftype eq 'HASH' && $key eq 'extensions';
                 push( @arguments, $key, $value );
             }

--- a/lib/App/pherkin.pm
+++ b/lib/App/pherkin.pm
@@ -297,7 +297,11 @@ sub _process_arguments {
         {
             die "Value of $key in config file expected to be HASH but isn't"
                 if ref $value ne 'HASH';
-            my @e = map { [ $_, [ $value->{$_} ] ] } keys %$value;
+            
+            # if the configuration of the extension is 'undef', then
+            # none was defined. Replace it with an empty hashref, which
+            # is what Moose's 'new()' method wants later on
+            my @e = map { [ $_, [ $value->{$_} || { } ] ] } keys %$value;
             $value = \@e;
             my $array = $additions{ 0 + $target } ||= [];
             push( @$array, @$value );

--- a/t/710_configuration_profiles.t
+++ b/t/710_configuration_profiles.t
@@ -67,7 +67,7 @@ $p->_process_arguments(
     '--steps'      => '4',
     '-o'           => 'Data',
     '-e'           => 'Test::CucumberExtensionPush({ id => 2, hash => {}})',
-    '--extensions' => 'Test::CucumberExtensionPush({ id => 3, hash => {}})',
+    '--extension' => 'Test::CucumberExtensionPush({ id => 3, hash => {}})',
 );
 
 isa_ok( $p->harness, 'Test::BDD::Cucumber::Harness::Data', 'Harness set' );

--- a/t/pherkin_config_files/readable.yaml
+++ b/t/pherkin_config_files/readable.yaml
@@ -16,6 +16,10 @@ ehuelsmann:
     - 1
     - 2
   output: JSON
-  extensions: Test::CucumberExtensionPush({ id => 1, hash => {}})
+  extensions:
+     Test::CucumberExtensionPush:
+        id: 1
+        hash:
+          key: value
   tags:
     - tag1,tag2,tag3


### PR DESCRIPTION
@pjlsergeant this commit makes the configuration of extensions in the config file into a hash of hashes.

The code didn't get much clearer, unfortunately. Otoh, I hope that specializing the 'extensions' configuration key helps keep things clean 'enough'.

After this one, there's another PR waiting which fixes an issue I found by coding my extension(s). Please hold releasing 0.48 until we have this *and* the other one discussed. If you want to merge it yourself: the change is sitting on my 'load-extension-steps' branch.