### PR TITLE
POD fixes

### DIFF
--- a/lib/Test/BDD/Cucumber/Harness.pm
+++ b/lib/Test/BDD/Cucumber/Harness.pm
@@ -42,7 +42,7 @@ sub feature_done { my ( $self, $feature ) = @_; }
 
 If you have a background section, then we execute it as a quasi-scenario step
 before each scenario. These hooks are fired before and after that, and passed
-in the L<Test::BDD::Cucmber::Model::Scenario> that represents the Background
+in the L<Test::BDD::Cucumber::Model::Scenario> that represents the Background
 section, and a a dataset hash (although why would you use that?)
 
 =cut
@@ -55,7 +55,7 @@ sub background_done { my ( $self, $scenario, $dataset ) = @_; }
 =head2 scenario_done
 
 Called at the start and end of scenario execution respectively. Both methods
-accept a L<Test::BDD::Cucmber::Model::Scenario> module and a dataset hash.
+accept a L<Test::BDD::Cucumber::Model::Scenario> module and a dataset hash.
 
 =cut
 
@@ -67,7 +67,7 @@ sub scenario_done { my ( $self, $scenario, $dataset ) = @_; }
 =head2 step_done
 
 Called at the start and end of step execution respectively. Both methods
-accept a L<Test::BDD::Cucmber::StepContext> object. C<step_done> also accepts
+accept a L<Test::BDD::Cucumber::StepContext> object. C<step_done> also accepts
 a L<Test::BDD::Cucumber::Model::Result> object and an arrayref of arrayrefs with
 locations of consolidated matches, for highlighting.
 

--- a/lib/Test/BDD/Cucumber/Loader.pm
+++ b/lib/Test/BDD/Cucumber/Loader.pm
@@ -12,12 +12,12 @@ Makes loading Step Definition files and Feature files a breeze...
 
 =head2 load
 
-Accepts a path, and returns a L<Test::BDD::Executor> object with the Step
-Definition files loaded, and a list of L<Test::BDD::Model::Feature> objects.
+Accepts a path, and returns a L<Test::BDD::Cucumber::Executor> object with the Step
+Definition files loaded, and a list of L<Test::BDD::Cucumber::Model::Feature> objects.
 
 =head2 load_steps
 
-Accepts an L<Test::BDD::Executor> object and a string representing either a
+Accepts an L<Test::BDD::Cucumber::Executor> object and a string representing either a
 step file, or a directory containing zero or more C<*_steps.pl> files, and loads
 the steps in to the executor; if you've used C<load> we'll have already scanned
 the feature directory for C<*_steps.pl> files.

--- a/lib/Test/BDD/Cucumber/Manual/Architecture.pod
+++ b/lib/Test/BDD/Cucumber/Manual/Architecture.pod
@@ -33,10 +33,10 @@ C<Test::BDD::Cucumber::Model>.
 
 =head1 EXECUTOR
 
-We build up a L<Test::BDD::Executor> object, in to which we load the step
-definitions. We then pass this in a L<Test::BDD::Model::Feature> object, along
-with a L<Test::BDD::Model::Harness> object, which controls interaction with
-the outside world.
+We build up a L<Test::BDD::Cucumber::Executor> object, in to which we load the
+step definitions. We then pass this in a L<Test::BDD::Cucumber::Model::Feature>
+object, along with a L<Test::BDD::Cucumber::Model::Harness> object, which
+controls interaction with the outside world.
 
 =head1 EXTENSION
 

--- a/lib/Test/BDD/Cucumber/Manual/Steps.pod
+++ b/lib/Test/BDD/Cucumber/Manual/Steps.pod
@@ -39,16 +39,16 @@ matches any.
 
  Given qr/I have (\d+)/, sub {
     S->{'count'} += $1;
- }
+ };
 
  When "The count is an integer", sub {
     S->{'count'} =
         int( S->{'count'} );
- }
+ };
 
  Then qr/The count should be (\d+)/, sub {
     is( S->{'count'}, C->matches->[0], "Count matches" );
- }
+ };
 
 Each of the exported verb functions accept a regular expression (or a string
 that's used as one), and a coderef. The coderef is passed a single argument,

--- a/lib/Test/BDD/Cucumber/Manual/Tutorial.pod
+++ b/lib/Test/BDD/Cucumber/Manual/Tutorial.pod
@@ -181,8 +181,6 @@ and C<S> is a function which returns the scenario stash. So the above can be
 written:
 
  Given qr/a Digest (\S+) object/, sub {
-    my $c = shift;
-
     my $object = Digest->new($1);
     ok( $object, "Object created" );
     S->{'object'} = $object;


### PR DESCRIPTION
- The 'Test::BDD::Cucumber' package name was misspelt as
  'Test::BDD::Cucmber' in some places.
- The '::Cucumber' package name component was missing in some places.
- The Step files manual page missed the trailing semicolons on some
  matcher declarations.
- The tutorial example using "S" instead of "$c->stash->{'scenario'}" can
  also be simplified to omit "$c" altogether, since it's not used.