### PR TITLE
* Remove File::Slurp dependency which warns on Perl 5.24

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,7 +26,6 @@ Digest::SHA = 0
 List::Util = 0
 List::MoreUtils = 0
 File::Find::Rule = 0
-File::Slurp = 9999.16
 Getopt::Long = 0
 IO::Scalar = 0
 JSON::MaybeXS = 1.001000

--- a/lib/Test/BDD/Cucumber/Parser.pm
+++ b/lib/Test/BDD/Cucumber/Parser.pm
@@ -28,8 +28,6 @@ L<Test::BDD::Cucumber::Model::Feature> object on success.
 use strict;
 use warnings;
 
-use File::Slurp;
-
 use Test::BDD::Cucumber::Model::Document;
 use Test::BDD::Cucumber::Model::Feature;
 use Test::BDD::Cucumber::Model::Scenario;
@@ -55,15 +53,19 @@ sub parse_string {
 
 sub parse_file {
     my ( $class, $string ) = @_;
-    return $class->_construct(
-        Test::BDD::Cucumber::Model::Document->new(
-            {
-                content =>
-                  scalar( read_file( $string, { binmode => ':utf8' } ) ),
-                filename => '' . $string
-            }
-        )
-    );
+    {
+        local $/;
+        open(my $in, '<', $string) or die $?;
+        binmode $in, 'utf8';
+        return $class->_construct(
+            Test::BDD::Cucumber::Model::Document->new(
+                {
+                    content => <$in>,
+                    filename => '' . $string
+                }
+            )
+        );
+    }
 }
 
 sub _construct {

--- a/t/310_auto_corpus.t
+++ b/t/310_auto_corpus.t
@@ -10,7 +10,6 @@ use Test::Differences;
 use Test::DumpFeature;
 use Test::BDD::Cucumber::Parser;
 use YAML::Syck;
-use File::Slurp;
 use File::Find::Rule;
 
 my @files = @ARGV;
@@ -19,7 +18,14 @@ my @files = @ARGV;
   unless @files;
 
 for my $file (@files) {
-    my $file_data = read_file($file);
+    my $file_data;
+
+    open(my $in, '<', $file) or die $?;
+    binmode $in, 'utf8';
+    {
+        local $/;
+        $file_data = <$in>;
+    }
     my ( $feature, $yaml ) = split( /----------DIVIDER----------/, $file_data );
     my $expected = Load($yaml);
     my $actual   = Test::DumpFeature::dump_feature(


### PR DESCRIPTION
Replace File::Slurp with a few lines of native code, because it produces "sysread() should not be used on utf-8 file handles" warnings.