### PR TITLE
* Don't buffer piped output so prove can consume it immediately

### DIFF
--- a/lib/TAP/Parser/SourceHandler/Feature.pm
+++ b/lib/TAP/Parser/SourceHandler/Feature.pm
@@ -69,6 +69,10 @@ sub make_iterator {
     my ( $input_fh, $output_fh );
     pipe $input_fh, $output_fh;
 
+    # Don't cache the output so prove sees it immediately
+    #  (pipes are stdio buffered by default)
+    $output_fh->autoflush(1);
+
     my $tb = Test::Builder->create();
     $tb->output($output_fh);
 


### PR DESCRIPTION
Note: This is the remedy for seemingly stalled tests