### PR TITLE
Start next "Scenario" even without empty lines

### DIFF
--- a/lib/Test/BDD/Cucumber/Parser.pm
+++ b/lib/Test/BDD/Cucumber/Parser.pm
@@ -269,6 +269,11 @@ m/^((?:$langdef->{given})|(?:$langdef->{and})|(?:$langdef->{when})|(?:$langdef->
         } elsif ( $line->content =~ m/^($langdef->{examples}):$/ ) {
             return $self->_extract_table( 6, $scenario,
                 $self->_remove_next_blanks(@lines) );
+        } elsif ( $line->content =~
+            m/^(?:(?:$langdef->{scenario})|(?:$langdef->{scenario_outline})):/ )
+        {
+            # next scenario begins here
+            return ($line, @lines);
         } else {
             die parse_error_from_line( "Malformed step line", $line );
         }

--- a/t/regressions/010_greedy_table_parsing/test.feature
+++ b/t/regressions/010_greedy_table_parsing/test.feature
@@ -11,7 +11,20 @@ Feature: Multiple Scenarios
                 | hexdigest | 3858f62230ac3c915f300c664312c63f |
                 | b64digest | 1B2M2Y8AsgTpgAmY7PhCfg           |
 
-    Scenario: Same test all over again
+    Scenario: Last step with multiline string
+        Given a Digest MD5 object
+         When I add "foo" to the object
+          And I add "bar" to the object
+         Then the hexdigest looks like:
+                """
+                3858f62230ac3c915f300c664312c63f
+                """
+          And the b64digest looks like:
+                """
+                1B2M2Y8AsgTpgAmY7PhCfg
+                """
+
+    Scenario: First test all over again
         Given a Digest MD5 object
          When I add "foo" to the object
           And I add "bar" to the object

--- a/t/regressions/010_greedy_table_parsing/test_steps.pl
+++ b/t/regressions/010_greedy_table_parsing/test_steps.pl
@@ -24,3 +24,12 @@ Then qr/the results look like/, sub {
         is $got, $expect, "test: $func";
     }
 };
+
+Then qr/the ((?:hex|b64)digest) looks like:/, sub {
+    my $func = $1;
+    my $expect = C->data;
+    chomp $expect;
+    my $digest = S->{digest};
+    my $got = $digest->$func();
+    is $got, $expect, "test: $func";
+};


### PR DESCRIPTION
Problem: The parser discards empty lines after a multiline string. So if the last step in a scenario has a multiline string, then the next "Scenario" is not a valid step and causes a syntax error. Self-referential example:

``` gherkin
  Scenario: Step data in last step
    When I use step data in the last step
    Then I get an error:
      """
      -- Parse Error --

       Malformed step line
        at ...
        thrown by: [/.../Test/BDD/Cucumber/Parser.pm] line 277

      ...
      """

  Scenario: This line is considered a malformed step
```

This commit terminates the scenario steps when there is an empty line or when a "Scenario:" or "Scenario Outline:" line is encountered.

I have a thorough refactoring of the parser ready on [a separate branch](https://github.com/latk/p5-Test-BDD-Cucumber/tree/simplified-parser) which stops special-casing of empty lines. I'll open another PR once this more important change is merged.