### PR TITLE
Unwind "execute_scenario" recursion

### DIFF
--- a/t/cucumber_core_features/step_definitions/core_steps.pl
+++ b/t/cucumber_core_features/step_definitions/core_steps.pl
@@ -110,6 +110,7 @@ When 'Cucumber runs the scenario with steps for a calculator', sub {
     S->{'executor'}->execute_scenario(
         {
             scenario      => S->{'feature'}->scenarios->[0],
+            scenario_stash => {},
             feature       => S->{'feature'},
             feature_stash => {},
             harness       => S->{'harness'}


### PR DESCRIPTION
The "execute_scenario" function in its current form is hard to grasp because it conflates a number of concerns:
- expansion of the outline
- execution of steps in a scenario (or background)
- inclusion of background steps in the execution of a scenario
- execution of pre- and post-amble steps
- finding matching step definitions and dispatching to them

With this PR, expansion of the outline moves to "execute_outline", execution of steps (irrespective of background or scenario) moves to "_execute_steps" and last but not least, the need to recurse back into 'execute_scenario' has been eliminated.

In short: the execution flow is now much more readable.
