### PR TITLE
Implement "match" mode

### DIFF
--- a/bin/pherkin
+++ b/bin/pherkin
@@ -32,6 +32,11 @@ Controlling @INC
  -b, --blib             Add 'blib/lib' and 'blib/arch' to @INC
  -I [dir]               Add given directory to @INC
 
+
+Controlling execution
+
+-m, --match             Only match steps in from features with available ones
+
 Output formatting
 
  -o, --output           Output harness. Defaults to 'TermColor'. See 'Outputs'

--- a/t/cucumber_core_features/step_definitions/core_steps.pl
+++ b/t/cucumber_core_features/step_definitions/core_steps.pl
@@ -110,6 +110,7 @@ When 'Cucumber runs the scenario with steps for a calculator', sub {
     S->{'executor'}->execute_scenario(
         {
             scenario      => S->{'feature'}->scenarios->[0],
+            scenario_stash => {},
             feature       => S->{'feature'},
             feature_stash => {},
             harness       => S->{'harness'}


### PR DESCRIPTION
This 'match' run mode serves to quickly identify which steps have
matching step functions and which ones don't.
The use-case for this functionality is that it doesn't require test
suites to set up any prerequisites (something which may consume time)
or to go through the exact steps of running the steps (which in case
of Selenium tests -- which I use T::B::C for) takes considerable time
too.