### PR TITLE
Fix the extension 'post_step' call always being passed 'failed' status

### DIFF
--- a/lib/Test/BDD/Cucumber/Executor.pm
+++ b/lib/Test/BDD/Cucumber/Executor.pm
@@ -500,7 +500,7 @@ sub find_and_dispatch {
 
     $_->pre_step( $step, $context ) for @{ $self->extensions };
     my $result = $self->dispatch( $context, $step, 0, $redispatch );
-    $_->post_step( $step, $context, $result eq 'passing' )
+    $_->post_step( $step, $context, ( $result->result ne 'passing' ), $result )
       for reverse @{ $self->extensions };
     return $result;
 }

--- a/lib/Test/BDD/Cucumber/Extension.pm
+++ b/lib/Test/BDD/Cucumber/Extension.pm
@@ -112,12 +112,17 @@ Feature and scenario stashes can be reached through
 
 Note: *executed* steps, so not called for skipped steps.
 
-=head2 post_step($step, $step_context, $failed)
+=head2 post_step($step, $step_context, $failed, $result)
 
 Invoked by the Executor after each executed step in $scenario.
 Reports errors by calling croak().
 
-$failure indicates whether the step has failed.
+$failed indicates that the step has not been completed succesfully;
+this means the step can have failed, be marked as TODO or pending
+(not implemented).
+
+$result is a C<Test::BDD::Cucumber::Model::Result> instance which
+holds the completion status of the step.
 
 Note: *executed* steps, so not called for skipped steps.
 


### PR DESCRIPTION
Since $result is a T::B::C::Model::Result, fix the value being passed
to the extension by passing the actual test result value.