### PR TITLE
Simple match mode

### DIFF
--- a/bin/pherkin
+++ b/bin/pherkin
@@ -32,6 +32,10 @@ Controlling @INC
  -b, --blib             Add 'blib/lib' and 'blib/arch' to @INC
  -I [dir]               Add given directory to @INC
 
+Controlling Execution
+
+ -m, --match            Only match steps in from features with available ones
+
 Output formatting
 
  -o, --output           Output harness. Defaults to 'TermColor'. See 'Outputs'


### PR DESCRIPTION
Hi @ehuelsmann,

Please find an alternative implementation of match mode which I think we should consider. I had initially agreed with your assessment that the executor was the right place to do this, but on further consideration, I think the change is made much simpler by taking the approach below.

It looks like you'd originally started you work to have `-m` be a toggle for match only, rather than a match mode. I think your original idea was right, and that we should resist adding a concept like modes until we know more about where we should do it, so I've used `-m` to mean match only here.

I don't think switching off extensions is the right choice here Extensions can possibly change how steps are selected, right? I think this is best handled via using a different config profile. This also allows match to be set more easily via configuration too. Someone doing complicated stuff via extensions is most likely already using configuration, etc, so adding a match profile seems like the right choice there?

Let me know what you think.

