### PR TITLE
Xenial doesn't provide Perl support yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: perl
 
 perl:


### PR DESCRIPTION
Although Travis decided to make it the default, even
for Perl projects...

Make sure we run on Trusty for now, because that's
still available and *does* provide Perl infrastructure.