### PR TITLE
Eliminate the empty line between successive features

### DIFF
--- a/lib/Test/BDD/Cucumber/Harness/TermColor.pm
+++ b/lib/Test/BDD/Cucumber/Harness/TermColor.pm
@@ -116,16 +116,6 @@ sub _colors {
 }
 
 my $margin = 2;
-
-sub BUILD {
-    my $self = shift;
-    my $fh   = $self->fh;
-
-    if ( $margin > 1 ) {
-        print $fh "\n" x ( $margin - 1 );
-    }
-}
-
 my $current_feature;
 
 sub feature {

--- a/t/800_regressions_020_term_color_skipped_steps.t
+++ b/t/800_regressions_020_term_color_skipped_steps.t
@@ -21,7 +21,6 @@ my $executor = Test::BDD::Cucumber::Executor->new();
 $executor->add_steps( [ Given => qr/(a) f(o)o b(a)r (baz)/, sub { 1; } ], );
 
 my $expected = <<END;
-
 [0]  [97]Foo[0]
 
 [0]    [97]Scenario: [94]Bar[0]


### PR DESCRIPTION
In 'prove' output, there's an empty line between feature files being reported.
This strictly happens for input files handled by Test::BDD::Cucumber; e.g.
pgTAP doesn't do this.

The source was hard to find, but this commit fixes #134.