### PR TITLE
Reap completed forked processes

### DIFF
--- a/lib/TAP/Parser/Iterator/PherkinStream.pm
+++ b/lib/TAP/Parser/Iterator/PherkinStream.pm
@@ -7,9 +7,10 @@ use base 'TAP::Parser::Iterator::Stream';
 
 
 sub _initialize {
-    my ($self, $fh, $pherkin) = @_;
+    my ($self, $fh, $pherkin, $child_pid) = @_;
 
     $self->{pherkin} = $pherkin;
+    $self->{child_pid} = $child_pid;
     return $self->SUPER::_initialize($fh);
 }
 
@@ -17,6 +18,9 @@ sub _finish {
     my $self = shift;
 
     $self->{pherkin}->_post_run();
+    if ($self->{child_pid}) {
+        waitpid $self->{child_pid}, 0; # reap child process
+    }
     return $self->SUPER::_finish(@_);
 }
 

--- a/lib/TAP/Parser/SourceHandler/Feature.pm
+++ b/lib/TAP/Parser/SourceHandler/Feature.pm
@@ -86,7 +86,7 @@ sub make_iterator {
     my $pid = fork;
     if ($pid) {
         close $output_fh;
-        return TAP::Parser::Iterator::PherkinStream->new($input_fh, $pherkin);
+        return TAP::Parser::Iterator::PherkinStream->new($input_fh, $pherkin, $pid);
     }
 
     close $input_fh;


### PR DESCRIPTION
Logging in on the CircleCI instance that runs part of the LedgerSMB test suite, I found a *lot* of `prove` processes. Thinking about the reason why that would be the case, I came to the conclusion that the "pherkin" processes that are being forked, are never reaped. So, here's the change to do exactly that.